### PR TITLE
Make sure to correctly clone Buffer properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,11 @@ var pagination = function(opts) {
 
         for (var i = 1; i < numPages; i++) {
             var cloneName = baseName + '-' + (i+1) + ext;
-            clone = cloneObj(file, true);
-            clone.contents = file.contents;
+            clone = cloneObj(file, true, function (value) {
+                if ( Buffer.isBuffer(value) ) {
+                    return value.slice();
+                }
+            });
 
             last.pagination.next = clone;
             clone.pagination.prev = last;

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,8 @@ describe('Paginate', function() {
     beforeEach(function(done) {
         files = {
             'blog.md': {
-                paginate: 'posts'
+                paginate: 'posts',
+                sidebar: new Buffer("I'm a sidebar content"),
             }
         }
 
@@ -70,5 +71,22 @@ describe('Paginate', function() {
         });
     });
 
+    it('takes care of Buffer properties while creating the virtual file for pagination', function (done) {
+        paginate({
+            perPage: 2,
+            path: ':collection/page'
+        })(files, metalsmith, function() {
+            var fileObj;
 
+            for (var file in files) {
+                if (/(posts\/page-[0-9]+)/.test(file)) {
+                    fileObj = files[file];
+                    should(fileObj).have.property('sidebar');
+                    should(fileObj.sidebar).not.equal(files['blog.md'].sidebar);
+                    should(Buffer.isBuffer(fileObj.sidebar)).ok;
+                }
+            }
+            done();
+        });
+    });
 });


### PR DESCRIPTION
The Buffer properties in the file object are not correctly handled, as a result, if a previous plugin (like metalsmith-include for instance) added a Buffer property, this one is not usable in the template of the _virtual_ files (you get `[Object object]` instead of the expected string). This is because, lodash.clone does not take care of the Buffer properties but fortunately it's easy to fix with a lodash.clone callback as explained in https://github.com/lodash/lodash/issues/311.

I also added a related unit test.
