### PR TITLE
`num` missing from `pagination` variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var pagination = function(opts) {
             clone.pagination.prev = last;
             clone.pagination.start = i * perPage;
             clone.pagination.end = i * perPage + perPage - 1;
-            clone.num = i+1;
+            clone.pagination.num = i+1;
 
             files[cloneName] = clone;
 


### PR DESCRIPTION
According to the readme, num should be available in the `pagination` variable. Fixed so it's there with the other pagination data. :)
